### PR TITLE
pin `light-the-torch` to `< 0.3.2`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ packages = find:
 include_package_data = True
 python_requires = >=3.6
 install_requires =
-    light-the-torch>=0.3
+    light-the-torch >= 0.3, < 0.3.2
     tox
 
 [options.packages.find]


### PR DESCRIPTION
[`light-the-torch==0.3.2`](https://github.com/pmeier/light-the-torch/releases/tag/v0.3.2) introduced some new semantics, that we should support in the future. For now we pin the dependency to use an earlier version.